### PR TITLE
Refactor word processing: update models to exclude page numbers in re…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 openai
 paddlepaddle-gpu
+# paddlepaddle-cpu
 pdf2image
 python-dotenv
 py-zerox

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -1,11 +1,11 @@
 from typing import List, Optional, Tuple
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class TextElement(BaseModel):
     text: str
-    page_number: Optional[int] = None
+    page_number: Optional[int] = Field(default=None, exclude=True)
 
 
 class Response(BaseModel):
@@ -13,5 +13,5 @@ class Response(BaseModel):
 
     @classmethod
     def from_result(cls, result: List[Tuple[str, Optional[int]]]):
-        items = [TextElement(text=item[0], page_number=item[1]) for item in result]
+        items = [TextElement(text=item[0], page_number=item[1] if item[1] is not None else None) for item in result]
         return cls(result=items)

--- a/src/routers/word_router.py
+++ b/src/routers/word_router.py
@@ -11,7 +11,7 @@ router = APIRouter()
 @router.post(
     "/word",
     response_model=Response,
-    response_description="List of chunks with page numbers.",
+    response_description="List of chunks.",
 )
 async def word(file: UploadFile = File(...)):
     """

--- a/src/services/word_service.py
+++ b/src/services/word_service.py
@@ -24,43 +24,37 @@ def unstructure_word(word_name):
     for chunk in chunks:
         if isinstance(chunk, CompositeElement):
             text = chunk.text
-            page_number = getattr(chunk.metadata, 'page_number', 1)  # Default to 1 if not available
-            text_list.append((text, page_number))
+            text_list.append(text)
         elif isinstance(chunk, Table):
-            page_number = getattr(chunk.metadata, 'page_number', 1)
             if text_list:
                 text_list[-1] = text_list[-1] + "\n" + chunk.metadata.text_as_html
             else:
-                text_list.append((chunk.metadata.text_as_html, page_number))
+                text_list.append(chunk.metadata.text_as_html)
 
     merged_list = []
     title_buffer = []
-    buffer_page: int = None
 
-    for text, page_number in text_list:
+    for text in text_list:
         stripped_text = text.strip()
         if stripped_text and (
             not stripped_text.endswith(".") and not "\n" in stripped_text
         ):  # This is a title block
             title_buffer.append(stripped_text)
-            if buffer_page is None:
-                buffer_page = page_number
         else:
             if title_buffer:
                 merged_title = "\n".join(title_buffer)
-                merged_text = f"{merged_title}\n{text}"
-                merged_list.append((merged_text, buffer_page))
+                merged_list.append((merged_title + "\n" + text, None))
                 title_buffer = []
-                buffer_page = None
             else:
-                merged_list.append((text, page_number))
+                merged_list.append((text, None))
 
     if title_buffer:
-        merged_title = "\n".join(title_buffer)
         if merged_list:
-            last_text, last_page = merged_list[-1]
-            merged_list[-1] = (f"{last_text}\n{merged_title}", last_page)
+            last_text, _ = merged_list[-1]
+            merged_list[-1] = (last_text + "\n" + "\n".join(title_buffer), None)
         else:
-            merged_list.append((merged_title, buffer_page if buffer_page else 1))
+            merged_list.append(("\n".join(title_buffer), None))
+    
+
 
     return merged_list


### PR DESCRIPTION
This pull request includes changes to the `src/models/models.py`, `src/routers/word_router.py`, and `src/services/word_service.py` files to modify the handling of page numbers in text elements. The most important changes include updating the `TextElement` model to exclude page numbers by default, adjusting the response description in the word router, and refactoring the unstructure_word function to remove page number handling.

Changes to models:

* [`src/models/models.py`](diffhunk://#diff-32c65642b81541b58973dfdc6406ee6eaa3b19467f9f89569ac4949f7d188d11L3-R16): Modified the `TextElement` model to exclude `page_number` by default using `Field`. Updated the `from_result` method to handle cases where `page_number` is `None`.

Changes to routers:

* [`src/routers/word_router.py`](diffhunk://#diff-d27be282af05750e7e6d9eca58e441c491c864d32dc1ce07699d1c05d468e952L14-R14): Updated the `response_description` in the word router to remove the mention of page numbers.

Changes to services:

* [`src/services/word_service.py`](diffhunk://#diff-c2ed1fc1c5a141cb6d937ebde0f8e6d6b8f80b702deae256c1d57c68e782d927L27-R58): Refactored the `unstructure_word` function to remove handling of page numbers, simplifying the text processing logic.…sponses, adjust word router description, and simplify text handling in word service